### PR TITLE
Fix issues with vscode and 1password on Linux Mint

### DIFF
--- a/roles-inline/1password/tasks/main.yml
+++ b/roles-inline/1password/tasks/main.yml
@@ -23,6 +23,12 @@
   become: true 
   when: ansible_os_family == "Debian" and not stat_1pbin_file.stat.exists
 
+- name: update apt cache
+  ansible.builtin.apt:
+    update_cache: yes
+  when: ansible_pkg_mgr == "apt"
+  become: true
+
 - name: install 1password-cli
   package:
     name: 1password-cli

--- a/roles-inline/vscode/tasks/main.yml
+++ b/roles-inline/vscode/tasks/main.yml
@@ -41,6 +41,7 @@
   apt:
     name: code
     state: present
+    update_cache: true
   become: true
   when: "'Ubuntu' in ansible_distribution or 'Pop!_OS' in ansible_distribution or 'Linux Mint' in ansible_distribution"
 


### PR DESCRIPTION
both the 1password and vscode roles needed to update apt cache before attempting to install